### PR TITLE
feat/possible names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ wheels/
 
 # cursor
 .cursorrules
+prompts/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "permalint"
-version = "0.1.13"
+version = "0.1.14"
 description = "Lint URLs"
 authors = [{ name = "Sanchit Ram Arvind", email = "sanchitram@gmail.com" }]
 dependencies = ["ruff~=0.0", "tldextract>=5.3.0"]

--- a/tests/test_possible_names.py
+++ b/tests/test_possible_names.py
@@ -16,19 +16,37 @@ from permalint import possible_names
         ),
         # in this case, the last path segment is the name
         ("mozilla.org/cbindgen", ["mozilla.org/cbindgen", "cbindgen"]),
-        # there's no path here, so we can check out the subdomain and domain
+        # for freedesktop.org, we only care about the domain name
         (
             "poppler.freedesktop.org",
-            ["poppler.freedesktop.org", "poppler", "freedesktop"],
+            ["poppler.freedesktop.org", "poppler"],
         ),
-        # there's a path here, so we're really only interested in the last
-        # segment
+        # since there's a path, we're only interseted in that last segment.
         (
             "poppler.freedesktop.org/poppler-data",
             ["poppler.freedesktop.org/poppler-data", "poppler-data"],
         ),
         ("elfutils.org", ["elfutils.org", "elfutils"]),
         ("hdfgroup.org/HDF5", ["hdfgroup.org/HDF5", "HDF5", "hdf5"]),
+        (
+            "gist.github.com/stning/89b6ce57e45a68e2da77a960770e5773",
+            ["gist.github.com/stning/89b6ce57e45a68e2da77a960770e5773"],
+        ),
+        (
+            "cloud.google.com/resource-manager/docs/resource-settings/overview",
+            [
+                "cloud.google.com/resource-manager/docs/resource-settings/overview",
+                "resource-manager",
+            ],
+        ),
+        ("giflib.sourceforge.net", ["giflib.sourceforge.net", "giflib"]),
+        (
+            "retrofox.github.com/calendar-tools",
+            ["retrofox.github.com/calendar-tools", "calendar-tools"],
+        ),
+        ("github.com/user/repo", ["github.com/user/repo", "repo"]),
+        ("gitlab.com/user/repo", ["gitlab.com/user/repo", "repo"]),
+        ("bitbucket.org/user/repo", ["bitbucket.org/user/repo", "repo"]),
     ],
 )
 def test_possible_names(input_name: str, probable_names: list[str]) -> None:


### PR DESCRIPTION
- prompts
- implement better possible naems
- bump


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the functionality of the `possible_names` function in the `permalint` package by enhancing URL handling, adding support for more platforms, and updating the package version.

### Detailed summary
- Updated version in `pyproject.toml` from `0.1.13` to `0.1.14`.
- Added new test cases in `tests/test_possible_names.py` for various URL formats.
- Enhanced the `possible_names` function in `src/permalint/__init__.py` to:
  - Always include the full URL first.
  - Extract repository names from known platforms (e.g., `github.com`, `gitlab.com`).
  - Handle specific cases for Google Cloud and SourceForge.
  - Added a main block to print example outputs for testing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->